### PR TITLE
Fix issue 10 by switching require('fs') to using Blob

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@
 ## Using iTrace-VSCode
 There are two options to use iTrace-VSCode. VSCode's extension API does not provide access to the underlying DOM information, iTrace-VSCode must be loaded in as JavaScript into VSCode's DOM.
 
-Tested on VSCode Version: [1.77.3](https://code.visualstudio.com/updates/v1_77).
-
-Note that versions of VSCode after 1.77.3 made a breaking change, and iTrace will fail to load in them.  This means you will need a separate installation of VSCode pinned to version 1.77.3.
+Tested on VSCode Version: [1.95.3](https://code.visualstudio.com/updates/v1_95).
 
 ## Current Limitations/Assumptions
 There is not currently support for having multiple editors visible at a time (e.g., split editing mode).  Tabbed editing works fine.

--- a/itrace.js
+++ b/itrace.js
@@ -1,26 +1,34 @@
-const fs = require("fs");
-
 class OutputFileWriter {
   constructor(directory, session_id) {
+    this.save_name = "itrace_vscode-" + (new Date()).getTime().toString() + ".xml";
     const filename = directory + "\\itrace_vscode-" + (new Date()).getTime().toString() + ".xml";
     console.log("iTrace: session started :: " + filename);
-    this.file = fs.createWriteStream(filename);
-    this.file.write("<?xml version=\"1.0\"?>\n");
-    this.file.write("<itrace_plugin session_id=\"" + session_id + "\">\n");
-    this.file.write("    <environment screen_width=\"" + window.screen.width.toString() + "\" screen_height=\"" + window.screen.height.toString() + "\" plugin_type=\"VSCODE\"/>\n");
-    this.file.write("    <gazes>\n");
+    // this.file = fs.createWriteStream(filename);
+    
+    this.file = ""
+    this.file += "<?xml version=\"1.0\"?>\n";
+    this.file += "<itrace_plugin session_id=\"" + session_id + "\">\n";
+    this.file += "    <environment screen_width=\"" + window.screen.width.toString() + "\" screen_height=\"" + window.screen.height.toString() + "\" plugin_type=\"VSCODE\"/>\n";
+    this.file += "    <gazes>\n";
   }
 
   close_writer() {
-    this.file.write("    </gazes>\n");
-    this.file.write("</itrace_plugin>\n");
-    this.file.end();
+    this.file += "    </gazes>\n";
+    this.file += "</itrace_plugin>\n";
+    
+    const blob = new Blob([this.file], { type:"text/plain"});
+    const link = document.createElement('a');
+    link.download = this.save_name;
+    link.href = URL.createObjectURL(blob);
+    link.click();
+    URL.revokeObjectURL(link.href);
+
     console.log("iTrace: session finished");
   }
 
   write_gaze(event_id, x, y) {
     let editor = CodePosServer.getFileRowCol(x, y, true);
-    this.file.write("        <response"
+    this.file += "        <response"
                     + " event_id=\"" + event_id + "\""
                     + " plugin_time=\"" + (new Date()).getTime().toString() + "\""
                     + " x=\"" + x + "\""
@@ -35,7 +43,7 @@ class OutputFileWriter {
                     + " editor_line_base_x=\"" + editor.lineLeft + "\""
                     + " editor_line_base_y=\"" + editor.lineTop + "\""
                     + "/>\n"
-                   );
+                  ;
   }
 }
 

--- a/itrace.js
+++ b/itrace.js
@@ -3,7 +3,6 @@ class OutputFileWriter {
     this.save_name = "itrace_vscode-" + (new Date()).getTime().toString() + ".xml";
     const filename = directory + "\\itrace_vscode-" + (new Date()).getTime().toString() + ".xml";
     console.log("iTrace: session started :: " + filename);
-    // this.file = fs.createWriteStream(filename);
     
     this.file = ""
     this.file += "<?xml version=\"1.0\"?>\n";

--- a/itrace.js
+++ b/itrace.js
@@ -1,8 +1,7 @@
 class OutputFileWriter {
   constructor(directory, session_id) {
     this.save_name = "itrace_vscode-" + (new Date()).getTime().toString() + ".xml";
-    const filename = directory + "\\itrace_vscode-" + (new Date()).getTime().toString() + ".xml";
-    console.log("iTrace: session started :: " + filename);
+    console.log("iTrace: session started :: " + this.save_name);
     
     this.file = ""
     this.file += "<?xml version=\"1.0\"?>\n";


### PR DESCRIPTION
I believe this fixes the script so it works in modern versions of VSCode. This no longer uses `require`, meaning it is "more pure" JavaScript.

This should be tested to ensure that it is still accurate and there is nothing wrong with the new file saving system.